### PR TITLE
Change semester parameter type to string

### DIFF
--- a/src/PSA.EduOutcome.Application.Contracts/Courses/Dtos/CourseDto.cs
+++ b/src/PSA.EduOutcome.Application.Contracts/Courses/Dtos/CourseDto.cs
@@ -39,7 +39,7 @@ namespace PSA.EduOutcome.Courses.Dtos
 
         public string PrerequisiteCourseName { get; set; }
 
-        public int Semester { get; set; }
+        public string Semester { get; set; }
 
         public int AcademicYear { get; set; }
     }

--- a/src/PSA.EduOutcome.Application.Contracts/Courses/ICourseAppService.cs
+++ b/src/PSA.EduOutcome.Application.Contracts/Courses/ICourseAppService.cs
@@ -25,6 +25,6 @@ namespace PSA.EduOutcome.Courses
         Task ImportFromExcelAsync(byte[] fileContent);
         Task<CourseStatisticsDto> GetStatisticsAsync(Guid id);
         Task<List<CourseDto>> GetPrerequisitesAsync(Guid id);
-        Task<List<CourseDto>> GetElectiveCoursesAsync(Guid programId, int semester);
+        Task<List<CourseDto>> GetElectiveCoursesAsync(Guid programId, string semester);
     }
 } 

--- a/src/PSA.EduOutcome.Application/Courses/CourseAppService.cs
+++ b/src/PSA.EduOutcome.Application/Courses/CourseAppService.cs
@@ -129,7 +129,7 @@ namespace PSA.EduOutcome.Courses
             return ObjectMapper.Map<List<Course>, List<CourseDto>>(prerequisites);
         }
 
-        public async Task<List<CourseDto>> GetElectiveCoursesAsync(Guid programId, int semester)
+        public async Task<List<CourseDto>> GetElectiveCoursesAsync(Guid programId, string semester)
         {
             var courses = await _courseRepository.GetElectiveCoursesAsync(programId, semester);
             return ObjectMapper.Map<List<Course>, List<CourseDto>>(courses);

--- a/src/PSA.EduOutcome.Domain/Repositories/ICourseRepository.cs
+++ b/src/PSA.EduOutcome.Domain/Repositories/ICourseRepository.cs
@@ -12,5 +12,6 @@ namespace PSA.EduOutcome.Domain.Repositories
         Task<List<Course>> GetCoursesByProgramAsync(Guid programId);
         Task<List<Course>> GetCoursesByInstructorAsync(Guid instructorId);
         Task<Course> FindByCodeAsync(string code);
+        Task<List<Course>> GetElectiveCoursesAsync(Guid programId, string semester);
     }
-} 
+}

--- a/src/PSA.EduOutcome.EntityFrameworkCore/Repositories/CourseRepository.cs
+++ b/src/PSA.EduOutcome.EntityFrameworkCore/Repositories/CourseRepository.cs
@@ -64,7 +64,7 @@ namespace PSA.EduOutcome.Courses
                 .ToListAsync();
         }
 
-        public async Task<List<Course>> GetElectiveCoursesAsync(Guid programId, int semester)
+        public async Task<List<Course>> GetElectiveCoursesAsync(Guid programId, string semester)
         {
             return await (await GetQueryableAsync())
                 .Where(c => c.ProgramId == programId &&

--- a/test/PSA.EduOutcome.EntityFrameworkCore.Tests/EntityFrameworkCore/Domains/CourseRepositoryTests.cs
+++ b/test/PSA.EduOutcome.EntityFrameworkCore.Tests/EntityFrameworkCore/Domains/CourseRepositoryTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using Shouldly;
+using Volo.Abp.Domain.Repositories;
+using Xunit;
+
+namespace PSA.EduOutcome.EntityFrameworkCore.Domains;
+
+[Collection(EduOutcomeTestConsts.CollectionDefinitionName)]
+public class CourseRepositoryTests : EduOutcomeEntityFrameworkCoreTestBase
+{
+    private readonly ICourseRepository _courseRepository;
+    private readonly IRepository<Course, Guid> _courseRepo;
+    private readonly IRepository<Program, Guid> _programRepo;
+    private readonly IRepository<Faculty, Guid> _facultyRepo;
+    private readonly IRepository<University, Guid> _universityRepo;
+
+    public CourseRepositoryTests()
+    {
+        _courseRepository = GetRequiredService<ICourseRepository>();
+        _courseRepo = GetRequiredService<IRepository<Course, Guid>>();
+        _programRepo = GetRequiredService<IRepository<Program, Guid>>();
+        _facultyRepo = GetRequiredService<IRepository<Faculty, Guid>>();
+        _universityRepo = GetRequiredService<IRepository<University, Guid>>();
+    }
+
+    [Fact]
+    public async Task Should_Filter_By_Semester_String()
+    {
+        var programId = Guid.NewGuid();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var uni = await _universityRepo.InsertAsync(new University(Guid.NewGuid(), "Test Uni", "TU"));
+            var fac = await _facultyRepo.InsertAsync(new Faculty(Guid.NewGuid(), "Fac", "FAC", uni.Id));
+            await _programRepo.InsertAsync(new Program(programId, "Prog", "PRG", "BSc", 8, 120, fac.Id));
+            await _courseRepo.InsertAsync(new Course(Guid.NewGuid(), "Course1", "C1", 3, "Fall", 2024, programId));
+            await _courseRepo.InsertAsync(new Course(Guid.NewGuid(), "Course2", "C2", 3, "Spring", 2024, programId));
+        });
+
+        var result = await WithUnitOfWorkAsync(() => _courseRepository.GetElectiveCoursesAsync(programId, "Fall"));
+
+        result.ShouldAllBe(c => c.Semester == "Fall");
+    }
+}


### PR DESCRIPTION
## Summary
- allow filtering courses by semester string
- expose GetElectiveCoursesAsync with a string semester argument
- support semester string in CourseDto
- test repository filtering by semester string

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684941b6a5508328acabdfd3f1e8f930