### PR TITLE
Add late penalty assessment test

### DIFF
--- a/src/PSA.EduOutcome.Domain/Entities/Question.cs
+++ b/src/PSA.EduOutcome.Domain/Entities/Question.cs
@@ -71,7 +71,7 @@ namespace PSA.EduOutcome.Entities
 
         public void SetQuestionType(string type)
         {
-            if (!QuestionType.IsValid(type))
+            if (!Entities.QuestionType.IsValid(type))
             {
                 throw new BusinessException($"Invalid question type: {type}");
             }

--- a/src/PSA.EduOutcome.Domain/Entities/Student.cs
+++ b/src/PSA.EduOutcome.Domain/Entities/Student.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Volo.Abp;
 using Volo.Abp.Domain.Entities.Auditing;
+using Volo.Abp.Guids;
 
 namespace PSA.EduOutcome.Entities
 {
@@ -44,7 +45,7 @@ namespace PSA.EduOutcome.Entities
         {
             var studentNumber = GenerateStudentNumber();
             return new Student(
-                GuidGenerator.Create(),
+                Guid.NewGuid(),
                 studentNumber,
                 firstName,
                 lastName,

--- a/test/PSA.EduOutcome.Domain.Tests/EduOutcomeDomainTestModule.cs
+++ b/test/PSA.EduOutcome.Domain.Tests/EduOutcomeDomainTestModule.cs
@@ -1,4 +1,7 @@
-﻿using Volo.Abp.Modularity;
+﻿using Volo.Abp;
+using Volo.Abp.Modularity;
+using Volo.Abp.Data;
+using Volo.Abp.DependencyInjection;
 
 namespace PSA.EduOutcome;
 
@@ -8,5 +11,9 @@ namespace PSA.EduOutcome;
 )]
 public class EduOutcomeDomainTestModule : AbpModule
 {
+    public override void OnApplicationInitialization(ApplicationInitializationContext context)
+    {
+        // Skip default test data seeding for lightweight unit tests
+    }
 
 }

--- a/test/PSA.EduOutcome.Domain.Tests/Samples/AssessmentTests.cs
+++ b/test/PSA.EduOutcome.Domain.Tests/Samples/AssessmentTests.cs
@@ -1,0 +1,29 @@
+using System;
+using PSA.EduOutcome.Entities;
+using Shouldly;
+using Xunit;
+
+namespace PSA.EduOutcome.Samples;
+
+public class AssessmentTests : EduOutcomeDomainTestBase<EduOutcomeDomainTestModule>
+{
+    [Fact]
+    public void CalculateFinalMark_Should_Apply_LatePenalty()
+    {
+        var dueDate = DateTime.Now.AddDays(1);
+        var assessment = new Assessment(
+            Guid.NewGuid(),
+            "Sample Assessment",
+            AssessmentType.Exam,
+            100m,
+            20m,
+            Guid.NewGuid(),
+            dueDate);
+
+        assessment.ConfigureLateSubmission(true, 10);
+
+        var result = assessment.CalculateFinalMark(80m, dueDate.AddDays(1));
+
+        result.ShouldBe(72m);
+    }
+}

--- a/test/PSA.EduOutcome.TestBase/EduOutcomeTestBaseModule.cs
+++ b/test/PSA.EduOutcome.TestBase/EduOutcomeTestBaseModule.cs
@@ -1,3 +1,4 @@
+using System;
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp;
 using Volo.Abp.Authorization;
@@ -29,7 +30,11 @@ public class EduOutcomeTestBaseModule : AbpModule
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)
     {
-        SeedTestData(context);
+        var skipSeed = Environment.GetEnvironmentVariable("SKIP_DATA_SEED");
+        if (skipSeed != "true")
+        {
+            SeedTestData(context);
+        }
     }
 
     private static void SeedTestData(ApplicationInitializationContext context)


### PR DESCRIPTION
## Summary
- add unit test for `Assessment.CalculateFinalMark`
- fix domain compilation issues
- skip data seeding in tests by environment variable

## Testing
- `SKIP_DATA_SEED=true ~/.dotnet/dotnet test test/PSA.EduOutcome.Domain.Tests/PSA.EduOutcome.Domain.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684941bdbfd08328ac95c4706c4fb4a3