### PR TITLE
Fix typo in OpenIddict data seeder comment

### DIFF
--- a/src/PSA.EduOutcome.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
+++ b/src/PSA.EduOutcome.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
@@ -18,7 +18,7 @@ using Volo.Abp.Uow;
 
 namespace PSA.EduOutcome.OpenIddict;
 
-/* Creates initial data that is needed to property run the application
+/* Creates initial data that is needed to properly run the application
  * and make client-to-server communication possible.
  */
 public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDependency


### PR DESCRIPTION
## Summary
- correct a typo in the OpenIddict data seeder comment

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684941b9f0148328b7253788104e59e0